### PR TITLE
Attempt to subclass `polars.DataFrame` in Python

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,8 +92,8 @@ dependencies = [
 
 [[package]]
 name = "arrow2"
-version = "0.11.1"
-source = "git+https://github.com/jorgecarleitao/arrow2?rev=3c64e7ab957880d9d6c72289c34fffd96a6c7030#3c64e7ab957880d9d6c72289c34fffd96a6c7030"
+version = "0.11.2"
+source = "git+https://github.com/ritchie46/arrow2?branch=improve_mutable#f7c3daf3da2cdeda916db91a66f6ef92752a8991"
 dependencies = [
  "arrow-format",
  "avro-schema",
@@ -838,6 +838,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
+name = "jemalloc-sys"
+version = "0.5.0+5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f655c3ecfa6b0d03634595b4b54551d4bd5ac208b9e0124873949a7ab168f70b"
+dependencies = [
+ "cc",
+ "fs_extra",
+ "libc",
+]
+
+[[package]]
+name = "jemallocator"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16c2514137880c52b0b4822b563fadd38257c1f380858addb74a400889696ea6"
+dependencies = [
+ "jemalloc-sys",
+ "libc",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1334,7 +1355,7 @@ dependencies = [
 [[package]]
 name = "polars"
 version = "0.21.1"
-source = "git+https://github.com/pola-rs/polars?rev=b796cf9b599559f76e354cc5a8ee23e85bf60c60#b796cf9b599559f76e354cc5a8ee23e85bf60c60"
+source = "git+https://github.com/pola-rs/polars?rev=eb31d98a612e3f5aaa9da08391c0e9e7173a65a1#eb31d98a612e3f5aaa9da08391c0e9e7173a65a1"
 dependencies = [
  "polars-core",
  "polars-io",
@@ -1346,7 +1367,7 @@ dependencies = [
 [[package]]
 name = "polars-arrow"
 version = "0.21.1"
-source = "git+https://github.com/pola-rs/polars?rev=b796cf9b599559f76e354cc5a8ee23e85bf60c60#b796cf9b599559f76e354cc5a8ee23e85bf60c60"
+source = "git+https://github.com/pola-rs/polars?rev=eb31d98a612e3f5aaa9da08391c0e9e7173a65a1#eb31d98a612e3f5aaa9da08391c0e9e7173a65a1"
 dependencies = [
  "arrow2",
  "hashbrown 0.12.1",
@@ -1358,7 +1379,7 @@ dependencies = [
 [[package]]
 name = "polars-core"
 version = "0.21.1"
-source = "git+https://github.com/pola-rs/polars?rev=b796cf9b599559f76e354cc5a8ee23e85bf60c60#b796cf9b599559f76e354cc5a8ee23e85bf60c60"
+source = "git+https://github.com/pola-rs/polars?rev=eb31d98a612e3f5aaa9da08391c0e9e7173a65a1#eb31d98a612e3f5aaa9da08391c0e9e7173a65a1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1370,9 +1391,9 @@ dependencies = [
  "hex",
  "indexmap",
  "jsonpath_lib",
- "lazy_static",
  "ndarray",
  "num",
+ "once_cell",
  "polars-arrow",
  "polars-utils",
  "rand",
@@ -1387,7 +1408,7 @@ dependencies = [
 [[package]]
 name = "polars-io"
 version = "0.21.1"
-source = "git+https://github.com/pola-rs/polars?rev=b796cf9b599559f76e354cc5a8ee23e85bf60c60#b796cf9b599559f76e354cc5a8ee23e85bf60c60"
+source = "git+https://github.com/pola-rs/polars?rev=eb31d98a612e3f5aaa9da08391c0e9e7173a65a1#eb31d98a612e3f5aaa9da08391c0e9e7173a65a1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1395,11 +1416,11 @@ dependencies = [
  "csv-core",
  "dirs",
  "flate2",
- "lazy_static",
  "lexical",
  "memchr",
  "memmap2",
  "num",
+ "once_cell",
  "polars-arrow",
  "polars-core",
  "polars-time",
@@ -1414,7 +1435,7 @@ dependencies = [
 [[package]]
 name = "polars-lazy"
 version = "0.21.1"
-source = "git+https://github.com/pola-rs/polars?rev=b796cf9b599559f76e354cc5a8ee23e85bf60c60#b796cf9b599559f76e354cc5a8ee23e85bf60c60"
+source = "git+https://github.com/pola-rs/polars?rev=eb31d98a612e3f5aaa9da08391c0e9e7173a65a1#eb31d98a612e3f5aaa9da08391c0e9e7173a65a1"
 dependencies = [
  "ahash",
  "glob",
@@ -1422,8 +1443,10 @@ dependencies = [
  "polars-arrow",
  "polars-core",
  "polars-io",
+ "polars-ops",
  "polars-time",
  "polars-utils",
+ "pyo3",
  "rayon",
  "regex",
  "serde",
@@ -1432,15 +1455,16 @@ dependencies = [
 [[package]]
 name = "polars-ops"
 version = "0.21.1"
-source = "git+https://github.com/pola-rs/polars?rev=b796cf9b599559f76e354cc5a8ee23e85bf60c60#b796cf9b599559f76e354cc5a8ee23e85bf60c60"
+source = "git+https://github.com/pola-rs/polars?rev=eb31d98a612e3f5aaa9da08391c0e9e7173a65a1#eb31d98a612e3f5aaa9da08391c0e9e7173a65a1"
 dependencies = [
+ "polars-arrow",
  "polars-core",
 ]
 
 [[package]]
 name = "polars-time"
 version = "0.21.1"
-source = "git+https://github.com/pola-rs/polars?rev=b796cf9b599559f76e354cc5a8ee23e85bf60c60#b796cf9b599559f76e354cc5a8ee23e85bf60c60"
+source = "git+https://github.com/pola-rs/polars?rev=eb31d98a612e3f5aaa9da08391c0e9e7173a65a1#eb31d98a612e3f5aaa9da08391c0e9e7173a65a1"
 dependencies = [
  "chrono",
  "lexical",
@@ -1452,7 +1476,7 @@ dependencies = [
 [[package]]
 name = "polars-utils"
 version = "0.21.1"
-source = "git+https://github.com/pola-rs/polars?rev=b796cf9b599559f76e354cc5a8ee23e85bf60c60#b796cf9b599559f76e354cc5a8ee23e85bf60c60"
+source = "git+https://github.com/pola-rs/polars?rev=eb31d98a612e3f5aaa9da08391c0e9e7173a65a1#eb31d98a612e3f5aaa9da08391c0e9e7173a65a1"
 dependencies = [
  "parking_lot",
  "rayon",
@@ -1541,11 +1565,12 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.13.29"
-source = "git+https://github.com/pola-rs/polars?rev=b796cf9b599559f76e354cc5a8ee23e85bf60c60#b796cf9b599559f76e354cc5a8ee23e85bf60c60"
+version = "0.13.39"
+source = "git+https://github.com/pola-rs/polars?rev=eb31d98a612e3f5aaa9da08391c0e9e7173a65a1#eb31d98a612e3f5aaa9da08391c0e9e7173a65a1"
 dependencies = [
  "ahash",
  "bincode",
+ "jemallocator",
  "libc",
  "mimalloc",
  "ndarray",
@@ -1553,10 +1578,10 @@ dependencies = [
  "once_cell",
  "polars",
  "polars-core",
+ "polars-lazy",
  "pyo3",
  "serde_json",
  "thiserror",
- "tikv-jemallocator",
 ]
 
 [[package]]
@@ -1979,27 +2004,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tikv-jemalloc-sys"
-version = "0.4.3+5.2.1-patched.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1792ccb507d955b46af42c123ea8863668fae24d03721e40cad6a41773dbb49"
-dependencies = [
- "cc",
- "fs_extra",
- "libc",
-]
-
-[[package]]
-name = "tikv-jemallocator"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5b7bcecfafe4998587d636f9ae9d55eb9d0499877b88757767c346875067098"
-dependencies = [
- "libc",
- "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "adler32"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
+
+[[package]]
 name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -20,6 +32,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "alloc-no-stdlib"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35ef4730490ad1c4eae5c4325b2a95f521d023e5c885853ff7aca0a6a1631db3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "697ed7edc0f1711de49ce108c541623a0af97c6c60b2f6e2b65229847ac843c2"
+dependencies = [
+ "alloc-no-stdlib",
 ]
 
 [[package]]
@@ -65,21 +92,31 @@ dependencies = [
 
 [[package]]
 name = "arrow2"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b040061368d1314b0fd8b8f1fde0671eba1afc63a1c61a4dafaf2d4fc10c96f9"
+version = "0.11.1"
+source = "git+https://github.com/jorgecarleitao/arrow2?rev=3c64e7ab957880d9d6c72289c34fffd96a6c7030#3c64e7ab957880d9d6c72289c34fffd96a6c7030"
 dependencies = [
  "arrow-format",
+ "avro-schema",
+ "base64",
  "bytemuck",
  "chrono",
+ "crc",
  "csv-core",
  "either",
+ "fallible-streaming-iterator",
+ "futures",
  "hash_hasher",
+ "indexmap",
  "lexical-core",
+ "libflate",
  "lz4",
  "multiversion",
  "num-traits",
+ "parquet2",
+ "serde",
+ "serde_json",
  "simdutf8",
+ "snap",
  "streaming-iterator",
  "strength_reduce",
  "zstd",
@@ -98,16 +135,103 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dad5c83079eae9969be7fadefe640a1c566901f05ff91ab221de4b6f68d9507e"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed6aa3524a2dfcf9fe180c51eae2b58738348d819517ceadf95789c51fff7600"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "avro-schema"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38707606731f68521a6f43d8089cee0278fbb235a967bc214dcb3238a1567c8"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitpacking"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8c7d2ac73c167c06af4a5f37e6e59d84148d57ccbe4480b76f0273eefea82d7"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
+name = "brotli"
+version = "3.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a0b1dbcc8ae29329621f8d4f0d835787c1c38bb1401979b49d13b0b305ff68"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ad2d4653bf5ca36ae797b1f4bb4dbddb60ce49ca4aed8a2ce4829f60425b80"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
 
 [[package]]
 name = "bytemuck"
@@ -191,6 +315,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49fc9a695bca7f35f5f4c15cddc84415f66a74ea78eef08e90c5024f2b540e23"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccaeedb56da03b09f598226e25e80088cb4cd25f316e6e4df7d695f0feeb1403"
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,12 +409,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
 name = "csv-core"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "ctor"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f877be4f7c9f246b183111634f75baa039715e3f46ce860677d3b19a69fb229c"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -296,6 +460,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,6 +479,112 @@ name = "fixedbitset"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
+
+[[package]]
+name = "flate2"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+dependencies = [
+ "crc32fast",
+ "libz-sys",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "fs_extra"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
+
+[[package]]
+name = "futures"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
+
+[[package]]
+name = "futures-task"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
+
+[[package]]
+name = "futures-util"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
 
 [[package]]
 name = "generic-array"
@@ -374,9 +650,9 @@ dependencies = [
 
 [[package]]
 name = "geojson"
-version = "0.22.3"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d90a7b840bb94d82b66d15bc5f28bc6f9ac017a32a72610a26dc98314ebf5d"
+checksum = "05d90d17275f3d3d1c6e64d2703e2667f875e2bb80437e4675537f87fec0f07c"
 dependencies = [
  "serde",
  "serde_derive",
@@ -408,6 +684,17 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi 0.10.2+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "ghost"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76c813ffb63e8fd3df6f1ac3cc1ea392c7612ac2de4d0b44dcbfe03e5c4bf94a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -484,13 +771,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "indexmap"
-version = "1.7.0"
+name = "hex"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "indexmap"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6012d540c5baa3589337a98ce73408de9b5a25ec9fc2c6fd6be8f0d39e0ca5a"
 dependencies = [
  "autocfg",
  "hashbrown 0.11.2",
+ "serde",
 ]
 
 [[package]]
@@ -506,6 +800,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "integer-encoding"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e85a1509a128c855368e135cffcde7eac17d8e1083f41e2b98c58bc1a5074be"
+dependencies = [
+ "async-trait",
+ "futures-util",
+]
+
+[[package]]
+name = "inventory"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84344c6e0b90a9e2b6f3f9abe5cc74402684e348df7b32adca28747e0cef091a"
+dependencies = [
+ "ctor",
+ "ghost",
 ]
 
 [[package]]
@@ -530,6 +844,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "jsonpath_lib"
+version = "0.3.0"
+source = "git+https://github.com/ritchie46/jsonpath?branch=improve_compiled#24eaf0b4416edff38a4d1b6b17bc4b9f3f047b4b"
+dependencies = [
+ "log",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -618,10 +942,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
+name = "libflate"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05605ab2bce11bcfc0e9c635ff29ef8b2ea83f29be257ee7d730cac3ee373093"
+dependencies = [
+ "adler32",
+ "crc32fast",
+ "libflate_lz77",
+]
+
+[[package]]
+name = "libflate_lz77"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a734c0493409afcd49deee13c006a04e3586b9761a03543c6272c9c51f2f5a"
+dependencies = [
+ "rle-decode-fast",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
+
+[[package]]
+name = "libmimalloc-sys"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ca136052550448f55df7898c6dbe651c6b574fe38a0d9ea687a9f8088a2e2c"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
+dependencies = [
+ "cc",
+ "cmake",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "lock_api"
@@ -663,6 +1029,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "add85d4dd35074e6fedc608f8c8f513a3548619a9024b751949ef0e8e45a4d84"
+dependencies = [
+ "rawpointer",
+]
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -684,6 +1059,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f64ad83c969af2e732e907564deb0d0ed393cec4af80776f77dd77a1a427698"
+dependencies = [
+ "libmimalloc-sys",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2b29bd4bc3f33391105ebee3589c19197c4271e3e5a9ec9bfe8127eeff8f082"
+dependencies = [
+ "adler",
 ]
 
 [[package]]
@@ -722,6 +1115,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "ndarray"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec23e6762830658d2b3d385a75aa212af2f67a4586d4442907144f3bb6a1ca8"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "rawpointer",
 ]
 
 [[package]]
@@ -812,6 +1218,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "numpy"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "383ae168529a39fc97cbc1d9d4fa865377731a519bc27553ed96f50594de7c45"
+dependencies = [
+ "libc",
+ "ndarray",
+ "num-complex",
+ "num-traits",
+ "pyo3",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -841,6 +1260,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "parquet-format-async-temp"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488c8b5f43521d019fade4bcc0ce88cce5da5fd26eb1d38b933807041f5930bf"
+dependencies = [
+ "async-trait",
+ "futures",
+ "integer-encoding",
+]
+
+[[package]]
+name = "parquet2"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbacca5619bdee7f942938890451dea1a61f082c682aac913d7b4e326e66d7b4"
+dependencies = [
+ "async-stream",
+ "bitpacking",
+ "brotli",
+ "flate2",
+ "futures",
+ "lz4",
+ "parquet-format-async-temp",
+ "snap",
+ "streaming-decompression",
+ "zstd",
+]
+
+[[package]]
 name = "pdqselect"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -848,13 +1296,31 @@ checksum = "4ec91767ecc0a0bbe558ce8c9da33c068066c57ecc8bb8477ef8c1ad3ef77c27"
 
 [[package]]
 name = "petgraph"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b305cc4569dd4e8765bab46261f67ef5d4d11a4b6e745100ee5dad8948b46c"
+checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
 dependencies = [
  "fixedbitset",
  "indexmap",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "planus"
@@ -868,8 +1334,7 @@ dependencies = [
 [[package]]
 name = "polars"
 version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b140da767e129c60c41c8e1968ffab5f114bcf823182edb7fa900464a31bf421"
+source = "git+https://github.com/pola-rs/polars?rev=b796cf9b599559f76e354cc5a8ee23e85bf60c60#b796cf9b599559f76e354cc5a8ee23e85bf60c60"
 dependencies = [
  "polars-core",
  "polars-io",
@@ -881,29 +1346,32 @@ dependencies = [
 [[package]]
 name = "polars-arrow"
 version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d27df11ee28956bd6f5aed54e7e05ce87b886871995e1da501134627ec89077"
+source = "git+https://github.com/pola-rs/polars?rev=b796cf9b599559f76e354cc5a8ee23e85bf60c60#b796cf9b599559f76e354cc5a8ee23e85bf60c60"
 dependencies = [
  "arrow2",
  "hashbrown 0.12.1",
  "num",
+ "serde",
  "thiserror",
 ]
 
 [[package]]
 name = "polars-core"
 version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdf8d12cb7ec278516228fc86469f98c62ab81ca31e4e76d2c0ccf5a09c70491"
+source = "git+https://github.com/pola-rs/polars?rev=b796cf9b599559f76e354cc5a8ee23e85bf60c60#b796cf9b599559f76e354cc5a8ee23e85bf60c60"
 dependencies = [
  "ahash",
  "anyhow",
  "arrow2",
+ "base64",
  "chrono",
  "comfy-table",
  "hashbrown 0.12.1",
+ "hex",
  "indexmap",
+ "jsonpath_lib",
  "lazy_static",
+ "ndarray",
  "num",
  "polars-arrow",
  "polars-utils",
@@ -911,20 +1379,22 @@ dependencies = [
  "rand_distr",
  "rayon",
  "regex",
+ "serde",
+ "serde_json",
  "thiserror",
 ]
 
 [[package]]
 name = "polars-io"
 version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd4b762e5694f359ded21ca0627b5bc95b6eb49f6b330569afc1d20f0564b01"
+source = "git+https://github.com/pola-rs/polars?rev=b796cf9b599559f76e354cc5a8ee23e85bf60c60#b796cf9b599559f76e354cc5a8ee23e85bf60c60"
 dependencies = [
  "ahash",
  "anyhow",
  "arrow2",
  "csv-core",
  "dirs",
+ "flate2",
  "lazy_static",
  "lexical",
  "memchr",
@@ -936,14 +1406,15 @@ dependencies = [
  "polars-utils",
  "rayon",
  "regex",
+ "serde",
+ "serde_json",
  "simdutf8",
 ]
 
 [[package]]
 name = "polars-lazy"
 version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eedc21001f05611e41bb7439b38d0f4ef9406aa49c17f3b289b5f57d8fa40c59"
+source = "git+https://github.com/pola-rs/polars?rev=b796cf9b599559f76e354cc5a8ee23e85bf60c60#b796cf9b599559f76e354cc5a8ee23e85bf60c60"
 dependencies = [
  "ahash",
  "glob",
@@ -954,13 +1425,14 @@ dependencies = [
  "polars-time",
  "polars-utils",
  "rayon",
+ "regex",
+ "serde",
 ]
 
 [[package]]
 name = "polars-ops"
 version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86fae68f0992955f224f09d1f15648a6fb76d8e3b962efac2f97ccc2aa58977a"
+source = "git+https://github.com/pola-rs/polars?rev=b796cf9b599559f76e354cc5a8ee23e85bf60c60#b796cf9b599559f76e354cc5a8ee23e85bf60c60"
 dependencies = [
  "polars-core",
 ]
@@ -968,20 +1440,19 @@ dependencies = [
 [[package]]
 name = "polars-time"
 version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be499f73749e820f96689c5f9ec59669b7cdd551d864358e2bdaebb5944e4bfb"
+source = "git+https://github.com/pola-rs/polars?rev=b796cf9b599559f76e354cc5a8ee23e85bf60c60#b796cf9b599559f76e354cc5a8ee23e85bf60c60"
 dependencies = [
  "chrono",
  "lexical",
  "polars-arrow",
  "polars-core",
+ "serde",
 ]
 
 [[package]]
 name = "polars-utils"
 version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f4cd569d383f5f000abbd6d5146550e6cb4e43fac30d1af98699499a440d56"
+source = "git+https://github.com/pola-rs/polars?rev=b796cf9b599559f76e354cc5a8ee23e85bf60c60#b796cf9b599559f76e354cc5a8ee23e85bf60c60"
 dependencies = [
  "parking_lot",
  "rayon",
@@ -1064,7 +1535,28 @@ dependencies = [
  "arctic",
  "polars",
  "polars-arrow",
+ "py-polars",
  "pyo3",
+]
+
+[[package]]
+name = "py-polars"
+version = "0.13.29"
+source = "git+https://github.com/pola-rs/polars?rev=b796cf9b599559f76e354cc5a8ee23e85bf60c60#b796cf9b599559f76e354cc5a8ee23e85bf60c60"
+dependencies = [
+ "ahash",
+ "bincode",
+ "libc",
+ "mimalloc",
+ "ndarray",
+ "numpy",
+ "once_cell",
+ "polars",
+ "polars-core",
+ "pyo3",
+ "serde_json",
+ "thiserror",
+ "tikv-jemallocator",
 ]
 
 [[package]]
@@ -1075,6 +1567,7 @@ checksum = "1e6302e85060011447471887705bb7838f14aba43fcb06957d823739a496b3dc"
 dependencies = [
  "cfg-if",
  "indoc",
+ "inventory",
  "libc",
  "parking_lot",
  "pyo3-build-config",
@@ -1176,6 +1669,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
 name = "rayon"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1246,6 +1745,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rle-decode-fast"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
+
+[[package]]
 name = "robust"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1313,6 +1818,7 @@ version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
 dependencies = [
+ "indexmap",
  "itoa",
  "ryu",
  "serde",
@@ -1355,10 +1861,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
+name = "slab"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
+
+[[package]]
 name = "smallvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+
+[[package]]
+name = "snap"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45456094d1983e2ee2a18fdfebce3189fa451699d0502cb8e3b49dba5ba41451"
 
 [[package]]
 name = "stable_deref_trait"
@@ -1371,6 +1889,15 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "streaming-decompression"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bc687acd5dc742c4a7094f2927a8614a68e4743ef682e7a2f9f0f711656cc92"
+dependencies = [
+ "fallible-streaming-iterator",
+]
 
 [[package]]
 name = "streaming-iterator"
@@ -1455,6 +1982,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tikv-jemalloc-sys"
+version = "0.4.3+5.2.1-patched.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1792ccb507d955b46af42c123ea8863668fae24d03721e40cad6a41773dbb49"
+dependencies = [
+ "cc",
+ "fs_extra",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5b7bcecfafe4998587d636f9ae9d55eb9d0499877b88757767c346875067098"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
 name = "time"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1493,6 +2041,12 @@ name = "unindent"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52fee519a3e570f7df377a06a1a7775cdbfb7aa460be7e08de2b1f0e69973a44"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-arrow2 = {version = "0.11.2", features = ["io_ipc"]}
+# arrow2 = {version = "0.11.2", features = ["io_ipc"]}
 geo = "0.20.1"
 geozero = {version = "0.9.4", features = ["with-wkb"]}
-polars = {version = "0.21.1", features = ["ipc", "dtype-u8"]}
+# polars = {version = "0.21.1", features = ["ipc", "dtype-u8"]}
+polars = {git = "https://github.com/pola-rs/polars", rev = "b796cf9b599559f76e354cc5a8ee23e85bf60c60", features = ["ipc", "dtype-u8"]}
+arrow2 = { package = "arrow2", git = "https://github.com/jorgecarleitao/arrow2", rev = "3c64e7ab957880d9d6c72289c34fffd96a6c7030", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,5 @@ edition = "2021"
 geo = "0.20.1"
 geozero = {version = "0.9.4", features = ["with-wkb"]}
 # polars = {version = "0.21.1", features = ["ipc", "dtype-u8"]}
-polars = {git = "https://github.com/pola-rs/polars", rev = "b796cf9b599559f76e354cc5a8ee23e85bf60c60", features = ["ipc", "dtype-u8"]}
-arrow2 = { package = "arrow2", git = "https://github.com/jorgecarleitao/arrow2", rev = "3c64e7ab957880d9d6c72289c34fffd96a6c7030", default-features = false }
+polars = {git = "https://github.com/pola-rs/polars", rev = "eb31d98a612e3f5aaa9da08391c0e9e7173a65a1", features = ["ipc", "dtype-u8"]}
+arrow2 = { package = "arrow2", git = "https://github.com/ritchie46/arrow2", branch = "improve_mutable", features = ["compute_concatenate"], default-features = false }

--- a/py-arctic/cargo.toml
+++ b/py-arctic/cargo.toml
@@ -13,8 +13,8 @@ crate-type = ["cdylib"]
 # polars-arrow = "0.21.1"
 # polars = {git = "https://github.com/pola-rs/polars"}
 # polars-arrow = {git = "https://github.com/pola-rs/polars"}
-polars = {git = "https://github.com/pola-rs/polars", rev = "b796cf9b599559f76e354cc5a8ee23e85bf60c60"}
-polars-arrow = {git = "https://github.com/pola-rs/polars", rev = "b796cf9b599559f76e354cc5a8ee23e85bf60c60"}
-py-polars = {git = "https://github.com/pola-rs/polars", rev = "b796cf9b599559f76e354cc5a8ee23e85bf60c60"}
+polars = {git = "https://github.com/pola-rs/polars", rev = "eb31d98a612e3f5aaa9da08391c0e9e7173a65a1"}
+polars-arrow = {git = "https://github.com/pola-rs/polars", rev = "eb31d98a612e3f5aaa9da08391c0e9e7173a65a1"}
+py-polars = {git = "https://github.com/pola-rs/polars", rev = "eb31d98a612e3f5aaa9da08391c0e9e7173a65a1"}
 pyo3 = { version = "0.16.4", features = ["extension-module"] }
 arctic = { path = "../" }

--- a/py-arctic/cargo.toml
+++ b/py-arctic/cargo.toml
@@ -9,7 +9,12 @@ name = "py_arctic"
 crate-type = ["cdylib"]
 
 [dependencies]
-polars = "0.21.1"
-polars-arrow = "0.21.1"
+# polars = "0.21.1"
+# polars-arrow = "0.21.1"
+# polars = {git = "https://github.com/pola-rs/polars"}
+# polars-arrow = {git = "https://github.com/pola-rs/polars"}
+polars = {git = "https://github.com/pola-rs/polars", rev = "b796cf9b599559f76e354cc5a8ee23e85bf60c60"}
+polars-arrow = {git = "https://github.com/pola-rs/polars", rev = "b796cf9b599559f76e354cc5a8ee23e85bf60c60"}
+py-polars = {git = "https://github.com/pola-rs/polars", rev = "b796cf9b599559f76e354cc5a8ee23e85bf60c60"}
 pyo3 = { version = "0.16.4", features = ["extension-module"] }
 arctic = { path = "../" }

--- a/py-arctic/rust-toolchain
+++ b/py-arctic/rust-toolchain
@@ -1,0 +1,1 @@
+nightly

--- a/py-arctic/src/geodataframe.rs
+++ b/py-arctic/src/geodataframe.rs
@@ -1,0 +1,86 @@
+#![allow(unused)]
+use arctic::geoseries::GeoSeries;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use py_polars::PyDataFrame;
+
+#[pyclass(extends=PyDataFrame, subclass)]
+struct GeoDataFrame {
+    val2: usize,
+}
+
+#[pymethods]
+impl GeoDataFrame {
+    #[new]
+    fn new() -> (Self, PyDataFrame) {
+        (SubClass { val2: 15 }, PyDataFrame::new())
+    }
+
+    // pub fn method(&self) -> PyResult<usize> {
+    //     Ok(self.val1)
+    // }
+}
+
+#[pyclass(subclass)]
+pub struct BaseClass {
+    val1: usize,
+}
+
+#[pymethods]
+impl BaseClass {
+    #[new]
+    fn new() -> Self {
+        BaseClass { val1: 10 }
+    }
+
+    pub fn method(&self) -> PyResult<usize> {
+        Ok(self.val1)
+    }
+}
+
+#[pyclass(extends=BaseClass, subclass)]
+pub struct SubClass {
+    val2: usize,
+}
+
+#[pymethods]
+impl SubClass {
+    #[new]
+    fn new() -> (Self, BaseClass) {
+        (SubClass { val2: 15 }, BaseClass::new())
+    }
+
+    fn method2(self_: PyRef<'_, Self>) -> PyResult<usize> {
+        let super_ = self_.as_ref(); // Get &BaseClass
+        super_.method().map(|x| x * self_.val2)
+    }
+}
+
+#[pyclass(extends=SubClass)]
+pub struct SubSubClass {
+    val3: usize,
+}
+
+#[pymethods]
+impl SubSubClass {
+    #[new]
+    fn new() -> PyClassInitializer<Self> {
+        PyClassInitializer::from(SubClass::new()).add_subclass(SubSubClass { val3: 20 })
+    }
+
+    fn method3(self_: PyRef<'_, Self>) -> PyResult<usize> {
+        let v = self_.val3;
+        let super_ = self_.into_super(); // Get PyRef<'_, SubClass>
+        SubClass::method2(super_).map(|x| x * v)
+    }
+}
+
+
+// fn main() {
+//     use pyo3::prelude::*;
+
+//     Python::with_gil(|py| {
+//         let subsub = pyo3::PyCell::new(py, SubSubClass::new()).unwrap();
+//         pyo3::py_run!(py, subsub, "assert subsub.method3() == 3000")
+//     });
+// }

--- a/py-arctic/src/lib.rs
+++ b/py-arctic/src/lib.rs
@@ -1,8 +1,10 @@
 mod ffi;
+pub mod geodataframe;
 
 use arctic::geoseries::GeoSeries;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
+use crate::geodataframe::{BaseClass, SubClass, SubSubClass};
 
 #[pyfunction]
 fn centroid(series: &PyAny) -> PyResult<PyObject> {
@@ -15,6 +17,9 @@ fn centroid(series: &PyAny) -> PyResult<PyObject> {
 
 #[pymodule]
 fn py_arctic(_py: Python, m: &PyModule) -> PyResult<()> {
-    m.add_wrapped(wrap_pyfunction!(centroid)).unwrap();
+    m.add_wrapped(wrap_pyfunction!(centroid))?;
+    m.add_class::<BaseClass>()?;
+    m.add_class::<SubClass>()?;
+    m.add_class::<SubSubClass>()?;
     Ok(())
 }


### PR DESCRIPTION
It would be cool to subclass `polars.DataFrame` in Python directly. Then we could more closely mimic the GeoPandas API. The PyO3 docs say it [should be possible](https://pyo3.rs/v0.16.4/class.html#inheritance) to implement a struct that acts as a Python subclass.

That said, `py-polars` is currently not published to crates.io and likely isn't intended to be used like this. Trying to compile from git fails