### PR TITLE
Adds convex_hull to geoseries and geodataframe

### DIFF
--- a/geopolars/src/geodataframe.rs
+++ b/geopolars/src/geodataframe.rs
@@ -3,11 +3,17 @@ use polars::prelude::{DataFrame, Result, Series};
 
 pub trait GeoDataFrame {
     fn centroid(&self) -> Result<Series>;
+    fn convex_hull(&self) -> Result<Series>;
 }
 
 impl GeoDataFrame for DataFrame {
     fn centroid(&self) -> Result<Series> {
         let geom_column = self.column("geometry")?;
         geom_column.centroid()
+    }
+
+    fn convex_hull(&self) -> Result<Series> {
+        let geom_column = self.column("geometry")?;
+        geom_column.convex_hull()
     }
 }

--- a/py-geopolars/src/lib.rs
+++ b/py-geopolars/src/lib.rs
@@ -13,8 +13,18 @@ fn centroid(series: &PyAny) -> PyResult<PyObject> {
     ffi::rust_series_to_py_series(&out)
 }
 
+#[pyfunction]
+fn convex_hull(series: &PyAny) -> PyResult<PyObject> {
+    let series = ffi::py_series_to_rust_series(series)?;
+    let out = series
+        .convex_hull()
+        .map_err(|e| PyValueError::new_err(format!("Something went wrong: {:?}", e)))?;
+    ffi::rust_series_to_py_series(&out)
+}
+
 #[pymodule]
 fn geopolars(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(centroid)).unwrap();
+    m.add_wrapped(wrap_pyfunction!(convex_hull)).unwrap();
     Ok(())
 }


### PR DESCRIPTION
This PR adds a convex_hull function for GeoSeries and GeoDataFrames.

The function is implemented for the follow GeoSeries types
- MultiPoint 
- MultiPolygon
- Polygon
- LineString 
- MultiLineString

Added test for MultiPoint case