### PR TITLE
Adding 2 length methods to GeoSeries

### DIFF
--- a/geopolars/src/geoseries.rs
+++ b/geopolars/src/geoseries.rs
@@ -31,11 +31,27 @@ pub trait GeoSeries {
     /// geometry.
     fn envelope(&self) -> Result<Series>;
 
+    /// Returns a Series with the value of the euclidean length of each geometry
+    ///
+    /// Calculates the euclidean length of each geometry in the series and returns it as a series.
+    /// Not valid for Point or MultiPoint geometries. For Polygon it's the
+    /// length of the exterior ring of the exterior ring of the Polygon and for MultiPolygon
+    /// it returns the
+    fn euclidean_length(&self) -> Result<Series>;
+
     /// Returns a GeoSeries of LinearRings representing the outer boundary of each polygon in the
     /// GeoSeries.
     ///
     /// Applies to GeoSeries containing only Polygons. Returns `None` for other geometry types.
     fn exterior(&self) -> Result<Series>;
+
+    /// Returns a Series with the value of the geodesic length of each geometry
+    ///
+    /// Calculates the geodesic length of each geometry in the series and returns it as a series.
+    /// Not valid for Point or MultiPoint geometries. For Polygon it's the
+    /// length of the exterior ring of the exterior ring of the Polygon and for MultiPolygon
+    /// it returns the
+    fn geodesic_length(&self) -> Result<Series>;
 
     /// Returns the type ids of each geometry
     /// This mimics the pygeos implementation
@@ -51,6 +67,14 @@ pub trait GeoSeries {
     /// MULTIPOLYGON is 6
     /// GEOMETRYCOLLECTION is 7
     fn geom_type(&self) -> Result<Series>;
+
+    /// Returns a Series with the value of the geodesic length of each geometry
+    ///
+    /// Calculates the haversine length of each geometry in the series and returns it as a series.
+    /// Not valid for Point or MultiPoint geometries. For Polygon it's the
+    /// length of the exterior ring of the exterior ring of the Polygon and for MultiPolygon
+    /// it returns the
+    fn haversine_length(&self) -> Result<Series>;
 
     /// Returns a boolean Series with value True for empty geometries
     fn is_empty(&self) -> Result<Series>;
@@ -150,6 +174,41 @@ impl GeoSeries for Series {
         Series::try_from(("geometry", Arc::new(result) as ArrayRef))
     }
 
+    fn euclidean_length(&self) -> Result<Series> {
+        use geo::algorithm::euclidean_length::EuclideanLength;
+        let mut result = MutablePrimitiveArray::<f64>::with_capacity(self.len());
+
+        for geom in iter_geom(self) {
+            let length: f64 = match geom {
+                Geometry::Point(_) => Ok(0.0),
+                Geometry::Line(line) => Ok(line.euclidean_length()),
+                Geometry::LineString(line_string) => Ok(line_string.euclidean_length()),
+                Geometry::Polygon(polygon) => Ok(polygon.exterior().euclidean_length()),
+                Geometry::MultiPoint(_) => Ok(0.0),
+                Geometry::MultiLineString(multi_line_string) => {
+                    Ok(multi_line_string.euclidean_length())
+                }
+                Geometry::MultiPolygon(mutli_polygon) => Ok(mutli_polygon
+                    .iter()
+                    .map(|poly| poly.exterior().euclidean_length())
+                    .sum()),
+                Geometry::GeometryCollection(_) => {
+                    Err(PolarsError::ComputeError(std::borrow::Cow::Borrowed(
+                        "Length methods are not implemented for geometry collection",
+                    )))
+                }
+                Geometry::Rect(rec) => Ok(rec.to_polygon().exterior().euclidean_length()),
+                Geometry::Triangle(triangle) => {
+                    Ok(triangle.to_polygon().exterior().euclidean_length())
+                }
+            }?;
+            result.push(Some(length));
+        }
+
+        let result: PrimitiveArray<f64> = result.into();
+        Series::try_from(("result", Arc::new(result) as ArrayRef))
+    }
+
     fn exterior(&self) -> Result<Series> {
         let mut output_array = MutableBinaryArray::<i32>::with_capacity(self.len());
 
@@ -167,6 +226,41 @@ impl GeoSeries for Series {
         let result: BinaryArray<i32> = output_array.into();
 
         Series::try_from(("geometry", Arc::new(result) as ArrayRef))
+    }
+
+    fn geodesic_length(&self) -> Result<Series> {
+        use geo::algorithm::geodesic_length::GeodesicLength;
+        let mut result = MutablePrimitiveArray::<f64>::with_capacity(self.len());
+
+        for geom in iter_geom(self) {
+            let length: f64 = match geom {
+                Geometry::Point(_) => Ok(0.0),
+                Geometry::Line(line) => Ok(line.geodesic_length()),
+                Geometry::LineString(line_string) => Ok(line_string.geodesic_length()),
+                Geometry::Polygon(polygon) => Ok(polygon.exterior().geodesic_length()),
+                Geometry::MultiPoint(_) => Ok(0.0),
+                Geometry::MultiLineString(multi_line_string) => {
+                    Ok(multi_line_string.geodesic_length())
+                }
+                Geometry::MultiPolygon(mutli_polygon) => Ok(mutli_polygon
+                    .iter()
+                    .map(|poly| poly.exterior().geodesic_length())
+                    .sum()),
+                Geometry::GeometryCollection(_) => {
+                    Err(PolarsError::ComputeError(std::borrow::Cow::Borrowed(
+                        "Length methods are not implemented for geometry collection",
+                    )))
+                }
+                Geometry::Rect(rec) => Ok(rec.to_polygon().exterior().geodesic_length()),
+                Geometry::Triangle(triangle) => {
+                    Ok(triangle.to_polygon().exterior().geodesic_length())
+                }
+            }?;
+            result.push(Some(length));
+        }
+
+        let result: PrimitiveArray<f64> = result.into();
+        Series::try_from(("result", Arc::new(result) as ArrayRef))
     }
 
     fn geom_type(&self) -> Result<Series> {
@@ -190,6 +284,42 @@ impl GeoSeries for Series {
         }
 
         let result: PrimitiveArray<i8> = result.into();
+        Series::try_from(("result", Arc::new(result) as ArrayRef))
+    }
+
+    fn haversine_length(&self) -> Result<Series> {
+        use geo::algorithm::haversine_length::HaversineLength;
+        let mut result = MutablePrimitiveArray::<f64>::with_capacity(self.len());
+
+        for geom in iter_geom(self) {
+            let length: f64 = match geom {
+                Geometry::Point(_) => Ok(0.0),
+                Geometry::Line(line) => Ok(line.haversine_length()),
+                Geometry::LineString(line_string) => Ok(line_string.haversine_length()),
+                Geometry::Polygon(polygon) => Ok(polygon.exterior().haversine_length()),
+                Geometry::MultiPoint(_) => Ok(0.0),
+                Geometry::MultiLineString(multi_line_string) => {
+                    Ok(multi_line_string.haversine_length())
+                }
+                Geometry::MultiPolygon(mutli_polygon) => Ok(mutli_polygon
+                    .iter()
+                    .map(|poly| poly.exterior().haversine_length())
+                    .sum()),
+                Geometry::GeometryCollection(_) => {
+                    Err(PolarsError::ComputeError(std::borrow::Cow::Borrowed(
+                        "Length methods are not implemented for geometry collection",
+                    )))
+                }
+                // Should these still call themselves polygon?
+                Geometry::Rect(rec) => Ok(rec.to_polygon().exterior().haversine_length()),
+                Geometry::Triangle(triangle) => {
+                    Ok(triangle.to_polygon().exterior().haversine_length())
+                }
+            }?;
+            result.push(Some(length));
+        }
+
+        let result: PrimitiveArray<f64> = result.into();
         Series::try_from(("result", Arc::new(result) as ArrayRef))
     }
 
@@ -296,7 +426,7 @@ mod tests {
     use std::sync::Arc;
 
     use arrow2::array::{ArrayRef, BinaryArray, MutableBinaryArray};
-    use geo::{polygon, Geometry, MultiPoint, Point, Polygon};
+    use geo::{line_string, polygon, Geometry, LineString, MultiPoint, Point, Polygon};
     use geozero::{CoordDimensions, ToWkb};
 
     #[test]
@@ -351,5 +481,89 @@ mod tests {
         let result = geom_iter.next().unwrap();
 
         assert_eq!(result, correct, "Should get the correct convex hull");
+    }
+
+    #[test]
+    fn euclidean_length() {
+        let mut test_data = MutableBinaryArray::<i32>::with_capacity(1);
+
+        let line_string: LineString<f64> = line_string![
+            (x: 1., y: 1.),
+            (x: 7., y: 1.),
+            (x: 8., y: 1.),
+            (x: 9., y: 1.),
+            (x: 10., y: 1.),
+            (x: 11., y: 1.)
+        ];
+
+        let line_string: Geometry<_> = line_string.into();
+
+        let test_wkb = line_string.to_wkb(CoordDimensions::xy()).unwrap();
+        test_data.push(Some(test_wkb));
+
+        let test_array: BinaryArray<i32> = test_data.into();
+
+        let series = Series::try_from(("geometry", Arc::new(test_array) as ArrayRef)).unwrap();
+        let lengths = series.euclidean_length().unwrap();
+        let as_vec: Vec<f64> = lengths.f64().unwrap().into_no_null_iter().collect();
+
+        assert_eq!(10.0_f64, as_vec[0]);
+    }
+    #[test]
+    fn haversine_length() {
+        let mut test_data = MutableBinaryArray::<i32>::with_capacity(1);
+
+        let line_string = LineString::<f64>::from(vec![
+            // New York City
+            (-74.006, 40.7128),
+            // London
+            (-0.1278, 51.5074),
+        ]);
+
+        let line_string: Geometry<_> = line_string.into();
+
+        let test_wkb = line_string.to_wkb(CoordDimensions::xy()).unwrap();
+        test_data.push(Some(test_wkb));
+
+        let test_array: BinaryArray<i32> = test_data.into();
+
+        let series = Series::try_from(("geometry", Arc::new(test_array) as ArrayRef)).unwrap();
+        let lengths = series.haversine_length().unwrap();
+        let as_vec: Vec<f64> = lengths.f64().unwrap().into_no_null_iter().collect();
+
+        assert_eq!(
+            5_570_230., // meters
+            as_vec[0].round()
+        );
+    }
+
+    #[test]
+    fn geodesic_length() {
+        let mut test_data = MutableBinaryArray::<i32>::with_capacity(1);
+
+        let line_string = LineString::<f64>::from(vec![
+            // New York City
+            (-74.006, 40.7128),
+            // London
+            (-0.1278, 51.5074),
+            // Osaka
+            (135.5244559, 34.687455),
+        ]);
+
+        let line_string: Geometry<_> = line_string.into();
+
+        let test_wkb = line_string.to_wkb(CoordDimensions::xy()).unwrap();
+        test_data.push(Some(test_wkb));
+
+        let test_array: BinaryArray<i32> = test_data.into();
+
+        let series = Series::try_from(("geometry", Arc::new(test_array) as ArrayRef)).unwrap();
+        let lengths = series.geodesic_length().unwrap();
+        let as_vec: Vec<f64> = lengths.f64().unwrap().into_no_null_iter().collect();
+
+        assert_eq!(
+            15_109_158., // meters
+            as_vec[0].round()
+        );
     }
 }

--- a/py-geopolars/src/lib.rs
+++ b/py-geopolars/src/lib.rs
@@ -1,6 +1,6 @@
 mod ffi;
 
-use geopolars::geoseries::GeoSeries;
+use geopolars::geoseries::{GeoSeries, GeodesicLengthMethod};
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
@@ -23,28 +23,19 @@ fn convex_hull(series: &PyAny) -> PyResult<PyObject> {
 }
 
 #[pyfunction]
-fn euclidean_distance(series: &PyAny) -> PyResult<PyObject> {
+fn euclidean_length(series: &PyAny) -> PyResult<PyObject> {
     let series = ffi::py_series_to_rust_series(series)?;
     let out = series
-        .euclidean_distance()
+        .euclidean_length()
         .map_err(|e| PyValueError::new_err(format!("Something went wrong: {:?}", e)))?;
     ffi::rust_series_to_py_series(&out)
 }
 
 #[pyfunction]
-fn geodesic_distance(series: &PyAny) -> PyResult<PyObject> {
+fn geodesic_length(series: &PyAny) -> PyResult<PyObject> {
     let series = ffi::py_series_to_rust_series(series)?;
     let out = series
-        .geodesic_distance()
-        .map_err(|e| PyValueError::new_err(format!("Something went wrong: {:?}", e)))?;
-    ffi::rust_series_to_py_series(&out)
-}
-
-#[pyfunction]
-fn haversine_distance(series: &PyAny) -> PyResult<PyObject> {
-    let series = ffi::py_series_to_rust_series(series)?;
-    let out = series
-        .haversine_distance()
+        .geodesic_length(GeodesicLengthMethod::Geodesic)
         .map_err(|e| PyValueError::new_err(format!("Something went wrong: {:?}", e)))?;
     ffi::rust_series_to_py_series(&out)
 }
@@ -53,8 +44,7 @@ fn haversine_distance(series: &PyAny) -> PyResult<PyObject> {
 fn geopolars(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(centroid)).unwrap();
     m.add_wrapped(wrap_pyfunction!(convex_hull)).unwrap();
-    m.add_wrapped(wrap_pyfunction!(euclidean_distance).unwrap());
-    m.add_wrapped(wrap_pyfunction!(geodesic_distance).unwrap());
-    m.add_wrapped(wrap_pyfunction!(haversine_distance).unwrap());
+    m.add_wrapped(wrap_pyfunction!(euclidean_length)).unwrap();
+    m.add_wrapped(wrap_pyfunction!(geodesic_length)).unwrap();
     Ok(())
 }

--- a/py-geopolars/src/lib.rs
+++ b/py-geopolars/src/lib.rs
@@ -31,11 +31,19 @@ fn euclidean_length(series: &PyAny) -> PyResult<PyObject> {
     ffi::rust_series_to_py_series(&out)
 }
 
-#[pyfunction]
-fn geodesic_length(series: &PyAny) -> PyResult<PyObject> {
+#[pyfunction(args="(method=\"geodesic\")")]
+fn geodesic_length(series: &PyAny, method: &str) -> PyResult<PyObject> {
     let series = ffi::py_series_to_rust_series(series)?;
+
+    let rust_method : GeodesicLengthMethod  = match method{
+        "geodesic" => Ok(GeodesicLengthMethod::Geodesic),
+        "haversine" => Ok(GeodesicLengthMethod::Haversine),
+        "vincenty" => Ok(GeodesicLengthMethod::Vincenty),
+        _ => Err(PyValueError::new_err("Geodesic calculation method not valid. Use one of geodesic, haversine or vincenty"))
+    }?;
+
     let out = series
-        .geodesic_length(GeodesicLengthMethod::Geodesic)
+        .geodesic_length(rust_method)
         .map_err(|e| PyValueError::new_err(format!("Something went wrong: {:?}", e)))?;
     ffi::rust_series_to_py_series(&out)
 }

--- a/py-geopolars/src/lib.rs
+++ b/py-geopolars/src/lib.rs
@@ -22,9 +22,39 @@ fn convex_hull(series: &PyAny) -> PyResult<PyObject> {
     ffi::rust_series_to_py_series(&out)
 }
 
+#[pyfunction]
+fn euclidean_distance(series: &PyAny) -> PyResult<PyObject> {
+    let series = ffi::py_series_to_rust_series(series)?;
+    let out = series
+        .euclidean_distance()
+        .map_err(|e| PyValueError::new_err(format!("Something went wrong: {:?}", e)))?;
+    ffi::rust_series_to_py_series(&out)
+}
+
+#[pyfunction]
+fn geodesic_distance(series: &PyAny) -> PyResult<PyObject> {
+    let series = ffi::py_series_to_rust_series(series)?;
+    let out = series
+        .geodesic_distance()
+        .map_err(|e| PyValueError::new_err(format!("Something went wrong: {:?}", e)))?;
+    ffi::rust_series_to_py_series(&out)
+}
+
+#[pyfunction]
+fn haversine_distance(series: &PyAny) -> PyResult<PyObject> {
+    let series = ffi::py_series_to_rust_series(series)?;
+    let out = series
+        .haversine_distance()
+        .map_err(|e| PyValueError::new_err(format!("Something went wrong: {:?}", e)))?;
+    ffi::rust_series_to_py_series(&out)
+}
+
 #[pymodule]
 fn geopolars(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(centroid)).unwrap();
     m.add_wrapped(wrap_pyfunction!(convex_hull)).unwrap();
+    m.add_wrapped(wrap_pyfunction!(euclidean_distance).unwrap());
+    m.add_wrapped(wrap_pyfunction!(geodesic_distance).unwrap());
+    m.add_wrapped(wrap_pyfunction!(haversine_distance).unwrap());
     Ok(())
 }


### PR DESCRIPTION
This adds the haversine, euclidean and geodesic length methods to the GeoSeries. 

For Polygons, MultiPolygons, Rects and Triangles, the methods calculate the total length of the exterior rings 

For Lines / MutliLines and LineStrings it returns the total length of the lines

For Points / MultiPoints it returns 0 as they technically have 0 length (this is what GeoPandas does as well)

It returns an error for GeometryCollections.

This should resolve #30 