### PR TITLE
Adding affine transform methods to GeoSeries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,15 +24,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
+checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
 
 [[package]]
 name = "approx"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f2a05fd1bd10b2527e20a2cd32d8873d115b8b39fe219ee25f42a8aca6ba278"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
  "num-traits",
 ]
@@ -73,18 +73,6 @@ dependencies = [
  "streaming-iterator",
  "strength_reduce",
  "zstd",
-]
-
-[[package]]
-name = "as-slice"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45403b49e3954a4b8428a0ac21a4b7afadccf92bfd96273f1a58cd4812496ae0"
-dependencies = [
- "generic-array 0.12.4",
- "generic-array 0.13.3",
- "generic-array 0.14.5",
- "stable_deref_trait",
 ]
 
 [[package]]
@@ -242,9 +230,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
+checksum = "4c02a4d71819009c192cf4872265391563fd6a84c81ff2c0f2a7026ca4c1d85c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -263,26 +251,26 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
+checksum = "07db9d94cbd326813772c968ccd25999e5f8ae22f4f8d1b11effa37ef6ce281d"
 dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "lazy_static",
  "memoffset",
+ "once_cell",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
+checksum = "7d82ee10ce34d7bc12c2122495e7593a9c41347ecdd64185af4ecf72cb1a7f83"
 dependencies = [
  "cfg-if",
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]
@@ -341,9 +329,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 
 [[package]]
 name = "embedded-hal"
@@ -371,56 +359,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
 
 [[package]]
-name = "generic-array"
-version = "0.12.4"
+name = "float_next_after"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+checksum = "4fc612c5837986b7104a87a0df74a5460931f1c5274be12f8d0f40aa2f30d632"
 dependencies = [
- "typenum",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f797e67af32588215eaaab8327027ee8e71b9dd0b2b26996aedf20c030fce309"
-dependencies = [
- "typenum",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
-dependencies = [
- "typenum",
- "version_check",
+ "num-traits",
 ]
 
 [[package]]
 name = "geo"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7e2e3be15682a45e9dfe9a04f84bff275390047204ab22f3c6b2312fcfb9e24"
+version = "0.22.0"
+source = "git+https://github.com/georust/geo.git?rev=578e213875915e1f895892487b5a36ca0d91fac3#578e213875915e1f895892487b5a36ca0d91fac3"
 dependencies = [
+ "float_next_after",
  "geo-types",
  "geographiclib-rs",
  "log",
  "num-traits",
  "robust",
- "rstar 0.8.4",
+ "rstar",
 ]
 
 [[package]]
 name = "geo-types"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5696e8138fbc44f64edc88b423afbe5a8f635df003376b3a57087e61a8ae7b66"
+checksum = "d9805fbfcea97de816e6408e938603241879cc41eea3fba3f84f122f4f6f9c54"
 dependencies = [
  "approx",
  "num-traits",
- "rstar 0.8.4",
+ "rstar",
 ]
 
 [[package]]
@@ -450,9 +419,10 @@ version = "0.1.0"
 dependencies = [
  "arrow2",
  "geo",
+ "geo-types",
  "geozero",
  "polars",
- "rstar 0.9.3",
+ "rstar",
 ]
 
 [[package]]
@@ -489,15 +459,6 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "hash32"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4041af86e63ac4298ce40e5cca669066e75b6f1aa3390fe2561ffa5e1d9f4cc"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "hash32"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
@@ -513,12 +474,6 @@ checksum = "74721d007512d0cb3338cd20f0654ac913920061a4c4d0d8708edb3f2a698c0c"
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-
-[[package]]
-name = "hashbrown"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
@@ -529,24 +484,12 @@ dependencies = [
 
 [[package]]
 name = "heapless"
-version = "0.6.1"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634bd4d29cbf24424d0a4bfcbf80c6960129dc24424752a7d1d1390607023422"
-dependencies = [
- "as-slice",
- "generic-array 0.14.5",
- "hash32 0.1.1",
- "stable_deref_trait",
-]
-
-[[package]]
-name = "heapless"
-version = "0.7.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a08e755adbc0ad283725b29f4a4883deee15336f372d5f61fae59efec40f983"
+checksum = "065681e99f9ef7e0e813702a0326aedbcbbde7db5e55f097aedd1bf50b9dca43"
 dependencies = [
  "atomic-polyfill",
- "hash32 0.2.1",
+ "hash32",
  "rustc_version 0.4.0",
  "spin",
  "stable_deref_trait",
@@ -578,12 +521,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.8.2"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6012d540c5baa3589337a98ce73408de9b5a25ec9fc2c6fd6be8f0d39e0ca5a"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
- "hashbrown 0.11.2",
+ "hashbrown",
 ]
 
 [[package]]
@@ -775,9 +718,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713d550d9b44d89174e066b7a6217ae06234c10cb47819a88290d2b353c31799"
+checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
  "log",
@@ -853,9 +796,9 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fbc387afefefd5e9e39493299f3069e14a140dd34dc19b4c1c1a8fddb6a790"
+checksum = "7ae39348c8bc5fbd7f40c727a9925f03517afd2ab27d46702108b6a7e5414c19"
 dependencies = [
  "num-traits",
 ]
@@ -883,9 +826,9 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
  "autocfg",
  "num-bigint",
@@ -943,12 +886,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pdqselect"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec91767ecc0a0bbe558ce8c9da33c068066c57ecc8bb8477ef8c1ad3ef77c27"
-
-[[package]]
 name = "petgraph"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -987,7 +924,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d27df11ee28956bd6f5aed54e7e05ce87b886871995e1da501134627ec89077"
 dependencies = [
  "arrow2",
- "hashbrown 0.12.1",
+ "hashbrown",
  "num",
  "thiserror",
 ]
@@ -1003,7 +940,7 @@ dependencies = [
  "arrow2",
  "chrono",
  "comfy-table",
- "hashbrown 0.12.1",
+ "hashbrown",
  "indexmap",
  "lazy_static",
  "num",
@@ -1097,9 +1034,9 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.39"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
+checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
 dependencies = [
  "unicode-ident",
 ]
@@ -1161,9 +1098,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
 dependencies = [
  "proc-macro2",
 ]
@@ -1307,23 +1244,11 @@ checksum = "e5864e7ef1a6b7bcf1d6ca3f655e65e724ed3b52546a0d0a663c991522f552ea"
 
 [[package]]
 name = "rstar"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a45c0e8804d37e4d97e55c6f258bc9ad9c5ee7b07437009dd152d764949a27c"
-dependencies = [
- "heapless 0.6.1",
- "num-traits",
- "pdqselect",
- "smallvec",
-]
-
-[[package]]
-name = "rstar"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b40f1bfe5acdab44bc63e6699c28b74f75ec43afb59f3eda01e145aff86a25fa"
 dependencies = [
- "heapless 0.7.13",
+ "heapless",
  "num-traits",
  "smallvec",
 ]
@@ -1343,14 +1268,14 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.10",
+ "semver 1.0.12",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
+checksum = "a0a5f7c728f5d284929a1cccb5bc19884422bfe6ef4d6c409da2c41838983fcf"
 
 [[package]]
 name = "ryu"
@@ -1381,9 +1306,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.10"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41d061efea015927ac527063765e73601444cdc344ba855bc7bd44578b25e1c"
+checksum = "a2333e6df6d6598f2b1974829f853c2b4c5f4a6e503c10af918081aa6f8564e1"
 
 [[package]]
 name = "semver-parser"
@@ -1413,9 +1338,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
+checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
 dependencies = [
  "itoa",
  "ryu",
@@ -1460,9 +1385,9 @@ checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
 name = "smallvec"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
 name = "spin"
@@ -1487,9 +1412,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "streaming-iterator"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "303235c177994a476226b80d076bd333b7b560fb05bd242a10609d11b07f81f5"
+checksum = "4817bfdf8f0b576330b83b55bed0ec89204aa7da62c2fa11fad2119f33a70014"
 
 [[package]]
 name = "strength_reduce"
@@ -1518,9 +1443,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.96"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0748dd251e24453cb8717f0354206b91557e4ec8703673a4b30208f2abaf1ebf"
+checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1571,12 +1496,6 @@ dependencies = [
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
 ]
-
-[[package]]
-name = "typenum"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "unicode-ident"
@@ -1713,11 +1632,12 @@ checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "wkt"
-version = "0.10.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6af44da55a2358b048c835ea3ff7cf41a7a27a273c974afd37dcf558eea886e1"
+checksum = "c3c2252781f8927974e8ba6a67c965a759a2b88ea2b1825f6862426bbb1c8f41"
 dependencies = [
  "geo-types",
+ "log",
  "num-traits",
  "thiserror",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,7 +419,6 @@ version = "0.1.0"
 dependencies = [
  "arrow2",
  "geo",
- "geo-types",
  "geozero",
  "polars",
  "rstar",

--- a/geopolars/Cargo.toml
+++ b/geopolars/Cargo.toml
@@ -6,8 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-arrow2 = {version = "0.11.2", features = ["io_ipc"]}
-geo = "0.20.1"
-geozero = {version = "0.9.4", features = ["with-wkb"]}
-polars = {version = "0.21.1", features = ["ipc", "dtype-u8", "dtype-i8"]}
+arrow2 = { version = "0.11.2", features = ["io_ipc"] }
+geozero = { version = "0.9.4", features = ["with-wkb"] }
 rstar = "0.9.3"
+geo = { git = "https://github.com/georust/geo.git", rev = '578e213875915e1f895892487b5a36ca0d91fac3' }
+polars = { version = "0.21.1", features = ["ipc", "dtype-u8", "dtype-i8"] }
+geo-types = { version = "0.7.6", features = ["approx", "use-rstar_0_9"] }

--- a/geopolars/Cargo.toml
+++ b/geopolars/Cargo.toml
@@ -11,4 +11,3 @@ geozero = { version = "0.9.4", features = ["with-wkb"] }
 rstar = "0.9.3"
 geo = { git = "https://github.com/georust/geo.git", rev = '578e213875915e1f895892487b5a36ca0d91fac3' }
 polars = { version = "0.21.1", features = ["ipc", "dtype-u8", "dtype-i8"] }
-geo-types = { version = "0.7.6", features = ["approx", "use-rstar_0_9"] }

--- a/geopolars/src/geoseries.rs
+++ b/geopolars/src/geoseries.rs
@@ -130,27 +130,6 @@ pub trait GeoSeries {
     fn y(&self) -> Result<Series>;
 }
 
-// struct Geom(geo::Geometry);
-
-// impl FromIterator<Geom> for Series{
-//     fn from_iter<T: IntoIterator<Item = Geom>>(iter: T) -> Self {
-//         let mut wkb_array = MutableBinaryArray::<i32>::new();
-
-//         for geom in iter{
-//             let wkb = geom.to_wkb(CoordDimensions::xy()).map_err(|_| {
-//                 PolarsError::ComputeError(std::borrow::Cow::Borrowed(
-//                     "Failed to convert geom vec to GeoSeries",
-//                 ))
-//             }).unwrap();
-//             wkb_array.push(Some(wkb));
-//         }
-//         let array: BinaryArray<i32> = wkb_array.into();
-
-//         let series = Series::try_from(("geometry", Arc::new(array) as ArrayRef)).unwrap();
-//         series
-//     }
-// }
-
 impl GeoSeries for Series {
     fn affine_transform(&self, matrix: impl Into<AffineTransform<f64>>) -> Result<Series> {
         let transform: AffineTransform<f64> = matrix.into();

--- a/geopolars/src/geoseries.rs
+++ b/geopolars/src/geoseries.rs
@@ -19,13 +19,14 @@ pub enum GeodesicLengthMethod {
 
 /// Used to express the origin for a given transform. Can be specified either be with reference to
 /// the geometry being transformed (Centroid, Center) or some arbitrary point.
+///
+/// - Centroid: Use the centriod of each geometry in the series as the transform origin.
+/// - Center: Use the center of each geometry in the series as the transform origin. The center is
+///   defined as the center of the bounding box of the geometry
+/// - Point: Define a single point to transform each geometry in the series about.
 pub enum TransformOrigin {
-    /// Use the centriod of each geometry in the series as the transform origin.
     Centroid,
-    /// Use the center of each geometry in the series as the transform origin. The center is
-    /// defined as the center of the bounding box of the geometry
     Center,
-    /// Define a single point to transform each geometry in the series about.
     Point(Point),
 }
 

--- a/geopolars/src/geoseries.rs
+++ b/geopolars/src/geoseries.rs
@@ -5,9 +5,11 @@ use arrow2::array::{
     ArrayRef, BinaryArray, BooleanArray, MutableBinaryArray, MutableBooleanArray,
     MutablePrimitiveArray, PrimitiveArray,
 };
-use geo::{Geometry, Point};
+use geo::algorithm::affine_ops::AffineTransform;
+use geo::{map_coords::MapCoords, Geometry, Point};
 use geozero::{CoordDimensions, ToWkb};
 use polars::prelude::{PolarsError, Result, Series};
+use std::convert::Into;
 
 pub enum GeodesicLengthMethod {
     Haversine,
@@ -15,7 +17,16 @@ pub enum GeodesicLengthMethod {
     Vincenty,
 }
 
+pub enum TransformOrigin {
+    Centroid,
+    Center,
+    Point(Point),
+}
+
 pub trait GeoSeries {
+    /// Apply an affine transform to the geoseries and return a geoseries of the tranformed geometries fn affine_transform(&self, matrix: impl Into<AffineTransform<f64>>  ) -> Result<Series>;
+    fn affine_transform(&self, matrix: impl Into<AffineTransform<f64>>) -> Result<Series>;
+
     /// Returns a Series containing the area of each geometry in the GeoSeries expressed in the
     /// units of the CRS.
     fn area(&self) -> Result<Series>;
@@ -87,6 +98,15 @@ pub trait GeoSeries {
     /// implicitly closed by copying the first tuple to the last index.
     fn is_ring(&self) -> Result<Series>;
 
+    /// Returns a GeoSeries with each of teh geometries roatered by a fixed x and y ammount arround
+    /// some origin.
+
+    fn rotate(&self, angle: f64, origin: TransformOrigin) -> Result<Series>;
+
+    /// Returns a GeoSeries with each of the geometries skewd by a fixed x and y amount around a
+    /// given origin
+    fn scale(&self, xfact: f64, yfact: f64, origin: TransformOrigin) -> Result<Series>;
+
     /// Returns a GeoSeries containing a simplified representation of each geometry.
     ///
     /// The algorithm (Douglas-Peucker) recursively splits the original line into smaller parts and
@@ -96,6 +116,13 @@ pub trait GeoSeries {
     /// https://docs.rs/geo/latest/geo/algorithm/simplify/trait.Simplify.html for details
     fn simplify(&self, tolerance: f64) -> Result<Series>;
 
+    /// Returns a GeoSeries with each of the geometries skewd by a fixed x and y amount around a
+    /// given origin
+    fn skew(&self, xs: f64, ys: f64, origin: TransformOrigin) -> Result<Series>;
+
+    /// Returns a GeoSeries with each of the geometries translated by a fixed x and y amount
+    fn translate(&self, x: f64, y: f64) -> Result<Series>;
+
     /// Return the x location of point geometries in a GeoSeries
     fn x(&self) -> Result<Series>;
 
@@ -103,7 +130,37 @@ pub trait GeoSeries {
     fn y(&self) -> Result<Series>;
 }
 
+// struct Geom(geo::Geometry);
+
+// impl FromIterator<Geom> for Series{
+//     fn from_iter<T: IntoIterator<Item = Geom>>(iter: T) -> Self {
+//         let mut wkb_array = MutableBinaryArray::<i32>::new();
+
+//         for geom in iter{
+//             let wkb = geom.to_wkb(CoordDimensions::xy()).map_err(|_| {
+//                 PolarsError::ComputeError(std::borrow::Cow::Borrowed(
+//                     "Failed to convert geom vec to GeoSeries",
+//                 ))
+//             }).unwrap();
+//             wkb_array.push(Some(wkb));
+//         }
+//         let array: BinaryArray<i32> = wkb_array.into();
+
+//         let series = Series::try_from(("geometry", Arc::new(array) as ArrayRef)).unwrap();
+//         series
+//     }
+// }
+
 impl GeoSeries for Series {
+    fn affine_transform(&self, matrix: impl Into<AffineTransform<f64>>) -> Result<Series> {
+        let transform: AffineTransform<f64> = matrix.into();
+        let output_vec: Vec<geo::Geometry> = iter_geom(self)
+            .map(|geom| geom.map_coords(|c| transform.apply(c)))
+            .collect();
+
+        Series::from_geom_vec(&output_vec)
+    }
+
     fn area(&self) -> Result<Series> {
         use geo::prelude::Area;
 
@@ -416,6 +473,68 @@ impl GeoSeries for Series {
         Series::try_from(("result", Arc::new(result) as ArrayRef))
     }
 
+    fn rotate(&self, angle: f64, origin: TransformOrigin) -> Result<Series> {
+        use geo::algorithm::bounding_rect::BoundingRect;
+        use geo::algorithm::centroid::Centroid;
+        match origin {
+            TransformOrigin::Centroid => {
+                let rotated_geoms: Vec<Geometry<f64>> = iter_geom(self)
+                    .map(|geom| {
+                        let centroid = geom.centroid().unwrap();
+                        let transform = AffineTransform::rotate(angle, centroid);
+                        geom.map_coords(|c| transform.apply(c))
+                    })
+                    .collect();
+                Series::from_geom_vec(&rotated_geoms)
+            }
+            TransformOrigin::Center => {
+                let rotated_geoms: Vec<Geometry<f64>> = iter_geom(self)
+                    .map(|geom| {
+                        let center = geom.bounding_rect().unwrap().center();
+                        let transform = AffineTransform::rotate(angle, center.into());
+                        geom.map_coords(|c| transform.apply(c))
+                    })
+                    .collect();
+                Series::from_geom_vec(&rotated_geoms)
+            }
+            TransformOrigin::Point(point) => {
+                let transform = AffineTransform::rotate(angle, point);
+                self.affine_transform(transform)
+            }
+        }
+    }
+
+    fn scale(&self, xfact: f64, yfact: f64, origin: TransformOrigin) -> Result<Series> {
+        use geo::algorithm::bounding_rect::BoundingRect;
+        use geo::algorithm::centroid::Centroid;
+        match origin {
+            TransformOrigin::Centroid => {
+                let rotated_geoms: Vec<Geometry<f64>> = iter_geom(self)
+                    .map(|geom| {
+                        let centroid = geom.centroid().unwrap();
+                        let transform = AffineTransform::scale(xfact, yfact, centroid);
+                        geom.map_coords(|c| transform.apply(c))
+                    })
+                    .collect();
+                Series::from_geom_vec(&rotated_geoms)
+            }
+            TransformOrigin::Center => {
+                let rotated_geoms: Vec<Geometry<f64>> = iter_geom(self)
+                    .map(|geom| {
+                        let center = geom.bounding_rect().unwrap().center();
+                        let transform = AffineTransform::scale(xfact, yfact, center.into());
+                        geom.map_coords(|c| transform.apply(c))
+                    })
+                    .collect();
+                Series::from_geom_vec(&rotated_geoms)
+            }
+            TransformOrigin::Point(point) => {
+                let transform = AffineTransform::scale(xfact, yfact, point);
+                self.affine_transform(transform)
+            }
+        }
+    }
+
     fn simplify(&self, tolerance: f64) -> Result<Series> {
         use geo::algorithm::simplify::Simplify;
 
@@ -442,6 +561,42 @@ impl GeoSeries for Series {
         let result: BinaryArray<i32> = output_array.into();
 
         Series::try_from(("geometry", Arc::new(result) as ArrayRef))
+    }
+
+    fn skew(&self, xs: f64, ys: f64, origin: TransformOrigin) -> Result<Series> {
+        use geo::algorithm::bounding_rect::BoundingRect;
+        use geo::algorithm::centroid::Centroid;
+        match origin {
+            TransformOrigin::Centroid => {
+                let rotated_geoms: Vec<Geometry<f64>> = iter_geom(self)
+                    .map(|geom| {
+                        let centroid = geom.centroid().unwrap();
+                        let transform = AffineTransform::skew(xs, ys, centroid);
+                        geom.map_coords(|c| transform.apply(c))
+                    })
+                    .collect();
+                Series::from_geom_vec(&rotated_geoms)
+            }
+            TransformOrigin::Center => {
+                let rotated_geoms: Vec<Geometry<f64>> = iter_geom(self)
+                    .map(|geom| {
+                        let center = geom.bounding_rect().unwrap().center();
+                        let transform = AffineTransform::skew(xs, ys, center.into());
+                        geom.map_coords(|c| transform.apply(c))
+                    })
+                    .collect();
+                Series::from_geom_vec(&rotated_geoms)
+            }
+            TransformOrigin::Point(point) => {
+                let transform = AffineTransform::skew(xs, ys, point);
+                self.affine_transform(transform)
+            }
+        }
+    }
+
+    fn translate(&self, x: f64, y: f64) -> Result<Series> {
+        let transform = AffineTransform::translate(x, y);
+        self.affine_transform(transform)
     }
 
     fn x(&self) -> Result<Series> {
@@ -493,8 +648,10 @@ mod tests {
     use std::sync::Arc;
 
     use arrow2::array::{ArrayRef, BinaryArray, MutableBinaryArray};
-    use geo::{line_string, polygon, Geometry, LineString, MultiPoint, Point, Polygon};
+    use geo::{line_string, polygon, CoordsIter, Geometry, LineString, MultiPoint, Point, Polygon};
     use geozero::{CoordDimensions, ToWkb};
+
+    use super::TransformOrigin;
 
     #[test]
     fn convex_hull_for_multipoint() {
@@ -548,6 +705,139 @@ mod tests {
         let result = geom_iter.next().unwrap();
 
         assert_eq!(result, correct, "Should get the correct convex hull");
+    }
+
+    #[test]
+    fn skew() {
+        let geo_series = Series::from_geom_vec(&vec![Geometry::Polygon(polygon!(
+        (x: 0.0,y:0.0),
+        (x: 0.0,y:1.0),
+        (x: 1.0,y: 1.0),
+        (x: 1.0,y: 0.0)
+        ))])
+        .unwrap();
+
+        let result: Geometry<f64> = Geometry::Polygon(polygon!(
+        (x:-0.008727532464108793,y:-0.017460384745873865),
+        (x:0.008727532464108793,y:0.9825396152541261),
+        (x:1.008727532464109, y:1.0174603847458739),
+        (x:0.9912724675358912, y:0.017460384745873865)
+        ));
+
+        let skewed_series = geo_series.skew(1.0, 2.0, TransformOrigin::Center);
+        assert!(skewed_series.is_ok(), "To get a series back");
+
+        let geom = iter_geom(&skewed_series.unwrap()).next().unwrap();
+        assert_eq!(geom, result, "the swkfddfg");
+        for (p1, p2) in geom.coords_iter().zip(result.coords_iter()) {
+            assert!(
+                (p1.x - p2.x).abs() < 0.00000001,
+                "The geometries x coords to be correct to within some tollerenace"
+            );
+            assert!(
+                (p1.y - p2.y).abs() < 0.00000001,
+                "The geometries y coords to be correct to within some tollerenace"
+            );
+        }
+    }
+
+    #[test]
+    fn rotate() {
+        let geo_series = Series::from_geom_vec(&vec![Geometry::Polygon(polygon!(
+        (x: 0.0,y:0.0),
+        (x: 0.0,y:1.0),
+        (x: 1.0,y: 1.0),
+        (x: 1.0,y: 0.0)
+        ))])
+        .unwrap();
+
+        let result: Geometry<f64> = Geometry::Polygon(polygon!(
+        (x:0.0,y:0.0),
+        (x:-1.0,y:0.0),
+        (x:-1.0, y:1.0),
+        (x:0.0, y:1.0)
+        ));
+
+        let rotated_series = geo_series.rotate(90.0, TransformOrigin::Point(Point::new(0.0, 0.0)));
+        assert!(rotated_series.is_ok(), "To get a series back");
+
+        let geom = iter_geom(&rotated_series.unwrap()).next().unwrap();
+        for (p1, p2) in geom.coords_iter().zip(result.coords_iter()) {
+            assert!(
+                (p1.x - p2.x).abs() < 0.00000001,
+                "The geometries x coords to be correct to within some tollerenace"
+            );
+            assert!(
+                (p1.y - p2.y).abs() < 0.00000001,
+                "The geometries y coords to be correct to within some tollerenace"
+            );
+        }
+    }
+
+    #[test]
+    fn translate() {
+        let geo_series = Series::from_geom_vec(&vec![Geometry::Polygon(polygon!(
+        (x: 0.0,y:0.0),
+        (x: 0.0,y:1.0),
+        (x: 1.0,y: 1.0),
+        (x: 1.0,y: 0.0)
+        ))])
+        .unwrap();
+
+        let result: Geometry<f64> = Geometry::Polygon(polygon!(
+        (x:1.0,y:1.0),
+        (x:1.0,y:2.0),
+        (x:2.0, y:2.0),
+        (x:2.0, y:1.0)
+        ));
+
+        let translated_series = geo_series.translate(1.0, 1.0);
+        assert!(translated_series.is_ok(), "To get a series back");
+
+        let geom = iter_geom(&translated_series.unwrap()).next().unwrap();
+        assert_eq!(geom, result, "The geom to be approprietly translated");
+    }
+
+    #[test]
+    fn scale() {
+        let geo_series = Series::from_geom_vec(&vec![Geometry::Polygon(polygon!(
+        (x: 0.0,y:0.0),
+        (x: 0.0,y:1.0),
+        (x: 1.0,y: 1.0),
+        (x: 1.0,y: 0.0)
+        ))])
+        .unwrap();
+
+        let result_center: Geometry<f64> = Geometry::Polygon(polygon!(
+        (x:-0.5,y:-0.5),
+        (x:-0.5,y:1.5),
+        (x:1.5, y:1.5),
+        (x:1.5, y:-0.5)
+        ));
+
+        let result_point: Geometry<f64> = Geometry::Polygon(polygon!(
+        (x:0.0,y:0.0),
+        (x:0.0,y:2.0),
+        (x:2.0, y:2.0),
+        (x:2.0, y:0.0)
+        ));
+
+        let scaled_series = geo_series.scale(2.0, 2.0, TransformOrigin::Center);
+        assert!(scaled_series.is_ok(), "To get a series back");
+
+        let geom = iter_geom(&scaled_series.unwrap()).next().unwrap();
+        assert_eq!(
+            geom, result_center,
+            "The geom to be approprietly scaled about it's center"
+        );
+
+        let scaled_series =
+            geo_series.scale(2.0, 2.0, TransformOrigin::Point(Point::new(0.0, 0.0)));
+        let geom = iter_geom(&scaled_series.unwrap()).next().unwrap();
+        assert_eq!(
+            geom, result_point,
+            "The geom to be approprietly scaled about the point 0,0"
+        );
     }
 
     #[test]

--- a/geopolars/src/geoseries.rs
+++ b/geopolars/src/geoseries.rs
@@ -137,7 +137,7 @@ pub trait GeoSeries {
     /// https://docs.rs/geo/latest/geo/algorithm/simplify/trait.Simplify.html for details
     fn simplify(&self, tolerance: f64) -> Result<Series>;
 
-    /// Returns a GeoSeries with each of the geometries skewd by a fixed x and y amount around a
+    /// Returns a GeoSeries with each of the geometries skewed by a fixed x and y amount around a
     /// given origin
     ///
     /// # Arguments

--- a/geopolars/src/geoseries.rs
+++ b/geopolars/src/geoseries.rs
@@ -709,7 +709,7 @@ mod tests {
 
     #[test]
     fn skew() {
-        let geo_series = Series::from_geom_vec(&vec![Geometry::Polygon(polygon!(
+        let geo_series = Series::from_geom_vec(&[Geometry::Polygon(polygon!(
         (x: 0.0,y:0.0),
         (x: 0.0,y:1.0),
         (x: 1.0,y: 1.0),
@@ -743,7 +743,7 @@ mod tests {
 
     #[test]
     fn rotate() {
-        let geo_series = Series::from_geom_vec(&vec![Geometry::Polygon(polygon!(
+        let geo_series = Series::from_geom_vec(&[Geometry::Polygon(polygon!(
         (x: 0.0,y:0.0),
         (x: 0.0,y:1.0),
         (x: 1.0,y: 1.0),
@@ -776,7 +776,7 @@ mod tests {
 
     #[test]
     fn translate() {
-        let geo_series = Series::from_geom_vec(&vec![Geometry::Polygon(polygon!(
+        let geo_series = Series::from_geom_vec(&[Geometry::Polygon(polygon!(
         (x: 0.0,y:0.0),
         (x: 0.0,y:1.0),
         (x: 1.0,y: 1.0),
@@ -800,7 +800,7 @@ mod tests {
 
     #[test]
     fn scale() {
-        let geo_series = Series::from_geom_vec(&vec![Geometry::Polygon(polygon!(
+        let geo_series = Series::from_geom_vec(&[Geometry::Polygon(polygon!(
         (x: 0.0,y:0.0),
         (x: 0.0,y:1.0),
         (x: 1.0,y: 1.0),


### PR DESCRIPTION
Adds affine transform methods from Geo to the GeoSeries 

Mehods added 
- translate 
- rotate
- skew
- scale
- affine_transform

Notes: 

- Added a Transform Origin to allow easy specification of the origin of a transform for those that accept one. 
- Currently the arguments of a transform are specified only by manual values. It would be great if you could specify another Series for these as well so that each geometry would be transformed according to the parameters in that series.
- The current implementation does not work in-place, we might want to have another set of functions to do the transforms in-place, updating the geometry column with the new geoms 
- Currently there is no method to chain together transforms, instead I would advise people compose the transform using methods from the geo crate and then apply that transform with the affine_transform method.

