### PR TITLE
Faster geometry indexing

### DIFF
--- a/geopolars/src/util.rs
+++ b/geopolars/src/util.rs
@@ -22,7 +22,7 @@ pub fn iter_geom(series: &Series) -> impl Iterator<Item = Geometry<f64>> + '_ {
 pub fn geom_at_index(series: &Series, index: usize) -> Result<Geometry<f64>> {
     let item_at_index = match series.get(index) {
         AnyValue::List(buf) => buf,
-        _ => return Err(PolarsError::SchemaMisMatch("".into()))
+        _ => return Err(PolarsError::SchemaMisMatch("".into())),
     };
 
     let buffer = item_at_index.u8()?;

--- a/geopolars/src/util.rs
+++ b/geopolars/src/util.rs
@@ -1,6 +1,10 @@
 use geo::Geometry;
 use geozero::{wkb::Wkb, ToGeo};
-use polars::prelude::{Result, Series};
+use polars::{
+    datatypes::AnyValue,
+    prelude::{PolarsError, Result, Series},
+};
+
 
 /// Helper function to iterate over geometries from polars Series
 pub fn iter_geom(series: &Series) -> impl Iterator<Item = Geometry<f64>> + '_ {
@@ -14,11 +18,14 @@ pub fn iter_geom(series: &Series) -> impl Iterator<Item = Geometry<f64>> + '_ {
     })
 }
 
+/// Access to a geometry at a specified index
 pub fn geom_at_index(series: &Series, index: usize) -> Result<Geometry<f64>> {
-    let chunks = series.list().expect("series was not a list type");
-    let row = chunks.into_iter().nth(index);
-    let value = row.expect("Row is null").expect("Failed to get row");
-    let buffer = value.u8().expect("Row is not of type u8");
+    let item_at_index = match series.get(index) {
+        AnyValue::List(buf) => buf,
+        _ => return Err(PolarsError::SchemaMisMatch("".into()))
+    };
+
+    let buffer = item_at_index.u8()?;
     let vec: Vec<u8> = buffer.into_iter().map(|x| x.unwrap()).collect();
     let geom = Wkb(vec).to_geo().expect("unable to convert geo");
     Ok(geom)

--- a/geopolars/src/util.rs
+++ b/geopolars/src/util.rs
@@ -7,7 +7,7 @@ use polars::{
 
 
 /// Helper function to iterate over geometries from polars Series
-pub fn iter_geom(series: &Series) -> impl Iterator<Item = Geometry<f64>> + '_ {
+pub(crate) fn iter_geom(series: &Series) -> impl Iterator<Item = Geometry<f64>> + '_ {
     let chunks = series.list().expect("series was not a list type");
     let iter = chunks.into_iter();
     iter.map(|row| {
@@ -19,7 +19,7 @@ pub fn iter_geom(series: &Series) -> impl Iterator<Item = Geometry<f64>> + '_ {
 }
 
 /// Access to a geometry at a specified index
-pub fn geom_at_index(series: &Series, index: usize) -> Result<Geometry<f64>> {
+pub(crate) fn geom_at_index(series: &Series, index: usize) -> Result<Geometry<f64>> {
     let item_at_index = match series.get(index) {
         AnyValue::List(buf) => buf,
         _ => return Err(PolarsError::SchemaMisMatch("".into())),

--- a/geopolars/src/util.rs
+++ b/geopolars/src/util.rs
@@ -5,7 +5,6 @@ use polars::{
     prelude::{PolarsError, Result, Series},
 };
 
-
 /// Helper function to iterate over geometries from polars Series
 pub(crate) fn iter_geom(series: &Series) -> impl Iterator<Item = Geometry<f64>> + '_ {
     let chunks = series.list().expect("series was not a list type");


### PR DESCRIPTION
#### Change list

- Change `geom_at_index` to use `series.get(index)` rather than iterating over the entire series. Using `nth` on an iterator is `O(n)` instead of `O(1)` because it needs to consume all the elements before it.
- I haven't actually benchmarked this, but I would expect it's faster.